### PR TITLE
Add uri hash operation support close #3

### DIFF
--- a/uri.sql
+++ b/uri.sql
@@ -130,6 +130,12 @@ CREATE FUNCTION uri_cmp(uri, uri) RETURNS integer
     LANGUAGE C
     AS '$libdir/uri';
 
+CREATE FUNCTION hash_uri(uri) RETURNS integer
+    IMMUTABLE
+    STRICT
+    LANGUAGE sql
+    AS $f$ SELECT hashtext(cast($1 AS text)); $f$;
+
 CREATE OPERATOR < (
     LEFTARG = uri,
     RIGHTARG = uri,
@@ -200,3 +206,8 @@ CREATE OPERATOR CLASS uri_ops
         OPERATOR        4       >= ,
         OPERATOR        5       > ,
         FUNCTION        1       uri_cmp(uri, uri);
+
+CREATE OPERATOR CLASS uri_ops_hash
+    FOR TYPE uri USING hash AS
+        OPERATOR 1 =,
+        FUNCTION 1 hash_uri(uri);


### PR DESCRIPTION
In some cases, it seems Postgresql adopts a hash join strategy. This fails if no hash operator classes have been defined for the involved type. This PR adds a basic `hash_uri` method and a `uri_ops_hash` operator class so Postgres can hash join on uri type fields.